### PR TITLE
Refine group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,9 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y -V libarrow-dev
-          sudo apt install -y -V libarrow-glib-dev
+          sudo apt install -y -V libarrow-dev=11.0.0-1
+          sudo apt install -y -V gir1.2-arrow-1.0=11.0.0-1
+          sudo apt install -y -V libarrow-glib-dev=11.0.0-1
 
       - name: Prepare Apache Arrow on macOS
         if: runner.os == 'macOS'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,6 +144,7 @@ Metrics/MethodLength:
     'format_table', # 53
     'slice_by', # 38
     'assign_update', # 35
+    'summarize', # 35
     'drop', # 32
     'aggregate', # 31
   ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,7 @@ Metrics/AbcSize:
     '[]', # 33.76
     'split', # 37.35
     'aggregate', # 38.13
+    'filter_table', # 31.11
   ]
 
 # Max: 25

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,7 +87,7 @@ Metrics/AbcSize:
     '[]', # 33.76
     'split', # 37.35
     'aggregate', # 38.13
-    'filter_table', # 31.11
+    'filters', # 33.91
   ]
 
 # Max: 25

--- a/Gemfile
+++ b/Gemfile
@@ -15,14 +15,13 @@ group :test do
   gem 'rubocop-rake'
   gem 'rubocop-rubycw', require: false
 
-  gem 'iruby'
-  gem 'test-unit'
-  gem 'webrick'
-  gem 'yard'
-
   gem 'benchmark_driver'
+  gem 'iruby'
   gem 'red-arrow-numo-narray'
   gem 'red-datasets-arrow'
   gem 'simplecov'
   gem 'simplecov-json'
+  gem 'test-unit'
+  gem 'webrick'
+  gem 'yard'
 end

--- a/benchmark/group.yml
+++ b/benchmark/group.yml
@@ -7,12 +7,16 @@ contexts:
   - name: 0.3.0
     gems:
       red_amber: 0.3.0
+  - name: 0.4.2
+    gems:
+      red_amber: 0.4.2
   - name: HEAD
     prelude: |
       $LOAD_PATH.unshift(File.expand_path('lib'))
 
 prelude: |
   require 'red_amber'
+  include RedAmber
   require 'datasets-arrow'
 
   ds = Datasets::Rdatasets.new('nycflights13', 'flights')
@@ -37,3 +41,6 @@ benchmark:
 
   'G05: sum dep_delay, arr_delay by carrer': |
     df.group(:carrier).sum(:dep_delay, :arr_delay)
+  
+  'G06: inspect': |
+    Group.new(df, :dest).inspect

--- a/benchmark/group.yml
+++ b/benchmark/group.yml
@@ -1,9 +1,6 @@
 loop_count: 3
 
 contexts:
-  - name: 0.2.2
-    gems:
-      red_amber: 0.2.2
   - name: 0.3.0
     gems:
       red_amber: 0.3.0
@@ -36,11 +33,14 @@ benchmark:
   'G03: sum arr_delay, mean distance by flight': |
     df.group(:flight) { [sum(:arr_delay), mean(:distance)] }
 
-  'G04: mean air_time, distance by flight': |
+  'G04:filtersir_time, distance by flight': |
     df.group(:flight).mean(:air_time, :distance)
 
-  'G05: sum dep_delay, arr_delay by carrer': |
+  'G75: sum dep_delay, arr_delay by carrer': |
     df.group(:carrier).sum(:dep_delay, :arr_delay)
   
-  'G06: inspect': |
+  'G06: filters': |
+    Group.new(df, :dest).filters
+
+  'G07: inspect': |
     Group.new(df, :dest).inspect

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -9,7 +9,7 @@ gem 'red-arrow', '~> 11.0.0'
 gem 'red-arrow-numo-narray'
 gem 'red-parquet', '~> 11.0.0'
 
-gem 'red_amber', '>=0.4.0'
+gem 'red_amber', path: '../'
 gem 'red-amber-view'
 gem 'rover-df'
 
@@ -18,4 +18,9 @@ gem 'red-datasets-arrow'
 
 gem 'benchmark_driver'
 gem 'benchmark-ips'
+
+gem 'charty'
 gem 'faker'
+gem 'matplotlib'
+gem 'pycall'
+gem 'unicode_plot'

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -1,11 +1,25 @@
+PATH
+  remote: ..
+  specs:
+    red_amber (0.5.0.pre.HEAD)
+      red-arrow (~> 11.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
     benchmark-ips (2.12.0)
     benchmark_driver (0.16.3)
     bigdecimal (3.1.4)
+    charty (0.2.12)
+      matplotlib (>= 1.2.0)
+      pandas (>= 0.3.5)
+      playwright-ruby-client
+      red-colors (>= 0.3.0)
+      red-datasets (>= 0.1.2)
+      red-palette (>= 0.5.0)
     concurrent-ruby (1.2.2)
     csv (3.2.6)
+    enumerable-statistics (2.0.7)
     extpp (0.1.1)
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
@@ -24,9 +38,24 @@ GEM
     irb (1.6.3)
       reline (>= 0.3.0)
     libui (0.0.15)
+    matplotlib (1.3.0)
+      pycall (>= 1.0.0)
+    matrix (0.4.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     native-package-installer (1.1.5)
     numo-narray (0.9.2.1)
+    numpy (0.4.0)
+      pycall (>= 1.2.0.beta1)
+    pandas (0.3.8)
+      numpy
+      pycall (>= 1.0.0)
     pkg-config (1.5.1)
+    playwright-ruby-client (1.32.0)
+      concurrent-ruby (>= 1.1.6)
+      mime-types (>= 3.0)
+    pycall (1.4.2)
     red-amber-view (0.0.1)
       libui
       red-arrow
@@ -40,6 +69,8 @@ GEM
     red-arrow-numo-narray (0.0.6)
       numo-narray
       red-arrow
+    red-colors (0.3.0)
+      matrix
     red-datasets (0.1.5)
       csv (>= 3.2.4)
       rexml
@@ -47,16 +78,18 @@ GEM
     red-datasets-arrow (0.0.3)
       red-arrow
       red-datasets (>= 0.0.3)
+    red-palette (0.5.0)
+      red-colors (>= 0.3.0)
     red-parquet (11.0.0)
       red-arrow (= 11.0.0)
-    red_amber (0.4.1)
-      red-arrow (~> 11.0.0)
     reline (0.3.2)
       io-console (~> 0.5)
     rexml (3.2.5)
     rover-df (0.3.4)
       numo-narray (>= 0.9.1.9)
     rubyzip (2.3.2)
+    unicode_plot (0.0.5)
+      enumerable-statistics (>= 2.0.1)
 
 PLATFORMS
   x86_64-linux
@@ -64,17 +97,21 @@ PLATFORMS
 DEPENDENCIES
   benchmark-ips
   benchmark_driver
+  charty
   faker
   irb
+  matplotlib
   numo-narray
+  pycall
   red-amber-view
   red-arrow (~> 11.0.0)
   red-arrow-numo-narray
   red-datasets
   red-datasets-arrow
   red-parquet (~> 11.0.0)
-  red_amber (>= 0.4.1)
+  red_amber!
   rover-df
+  unicode_plot
 
 BUNDLED WITH
-   2.4.8
+   2.4.12

--- a/docker/example
+++ b/docker/example
@@ -1,46 +1,46 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-$stderr.print "starting.\r"
+print "starting.\r"
 
-require 'bundler/setup'
+Dir.chdir(__dir__) { require 'bundler/setup' }
 
-$stderr.print "starting..\r"
+print "starting..\r"
 require 'red_amber'
 include RedAmber
 
-$stderr.print "starting...\r"
+print "starting...\r"
 require 'datasets-arrow'
 
-$stderr.print "reading penguins...\r"
+print "reading penguins...\r"
 penguins = DataFrame.new(Datasets::Penguins.new)
 
-$stderr.print "reading diamonds...\r"
+print "reading diamonds...\r"
 diamonds = DataFrame.new(Datasets::Diamonds.new)
 
-$stderr.print "reading starwars...\r"
+print "reading starwars...\r"
 starwars = DataFrame.new(Datasets::Rdataset.new('dplyr', 'starwars'))
 
-$stderr.print "reading openintro/simpsons_paradox_covid...\r"
+print "reading openintro/simpsons_paradox_covid...\r"
 ds = Datasets::Rdataset.new('openintro', 'simpsons_paradox_covid')
 simpsons_paradox_covid = DataFrame.new(ds.to_arrow)
 
-$stderr.print "reading mtcars...                          \r"
+print "reading mtcars...                          \r"
 mtcars = DataFrame.new(Datasets::Rdatasets.new('datasets', 'mtcars'))
 
-$stderr.print "reading iris...  \r"
+print "reading iris...  \r"
 iris = DataFrame.new(Datasets::Iris.new)
 
-$stderr.print "reading band_members...\r"
+print "reading band_members...\r"
 band_members = DataFrame.new(Datasets::Rdatasets.new('dplyr', 'band_members'))
 
-$stderr.print "reading band_instruments...\r"
+print "reading band_instruments...\r"
 band_instruments = DataFrame.new(Datasets::Rdatasets.new('dplyr', 'band_instruments'))
 
-$stderr.print "reading band_instruments2...\r"
+print "reading band_instruments2...\r"
 band_instruments2 = DataFrame.new(Datasets::Rdatasets.new('dplyr', 'band_instruments2'))
 
-$stderr.print "reading import_cars...      \r"
+print "reading import_cars...      \r"
 import_cars = DataFrame.load(Arrow::Buffer.new(<<~TSV), format: :tsv)
   Year	Audi	BMW	BMW_MINI	Mercedes-Benz	VW
   2017	28336	52527	25427	68221	49040
@@ -50,7 +50,7 @@ import_cars = DataFrame.load(Arrow::Buffer.new(<<~TSV), format: :tsv)
   2021	22535	35905	18211	51722	35215
 TSV
 
-$stderr.print "reading comecome...   \r"
+print "reading comecome...   \r"
 comecome = DataFrame.load(Arrow::Buffer.new(<<~CSV), format: :csv)
   name,age
   Yasuko,68
@@ -58,7 +58,19 @@ comecome = DataFrame.load(Arrow::Buffer.new(<<~CSV), format: :csv)
   Hinata,28
 CSV
 
-$stderr.print "reading general dataframe and subframes...\r"
+print "reading rubykaigi...   \r"
+rubykaigi = DataFrame.load(Arrow::Buffer.new(<<~CSV), format: :csv)
+  year,venue,prefecture,city,venue_en
+  2015,ベルサール汐留,東京都,中央区,"Bellesalle Shiodome"
+  2016,京都国際会議場,京都府,京都市左京区,"Kyoto International Conference Center"
+  2017,広島国際会議場,広島県,広島市中区,"International Conference Center Hiroshima"
+  2018,仙台国際センター,宮城県,仙台市青葉区,"Sendai International Center"
+  2019,福岡国際会議場,福岡県,福岡市博多区,"Fukuoka International Congress Center"
+  2022,三重県総合文化センター,三重県,津市,"Mie Center for the Arts"
+  2023,松本市民芸術館,長野県,松本市,"Matsumoto Performing Arts Centre"
+CSV
+
+print "reading general dataframe and subframes...\r"
 dataframe = DataFrame.new(
   x: [*1..6],
   y: %w[A A B B B C],
@@ -70,5 +82,5 @@ subframes = SubFrames.new(dataframe, [[0, 1], [2, 3, 4], [5]])
 # This environment will offer these pre-loaded datasets:
 #   penguins, diamonds, iris, starwars, simpsons_paradox_covid,
 #   mtcars, band_members, band_instruments, band_instruments2
-#   (original) import_cars, comecome, dataframe, subframes
+#   import_cars, comecome, rubykaigi, dataframe, subframes
 binding.irb

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -422,12 +422,12 @@ module RedAmber
     # Create SubFrames by value grouping.
     #
     # [Experimental feature] this method may be removed or be changed in the future.
-    # @param keys [Symbol, String, Array<Symbol, String>]
+    # @param keys [List<Symbol, String>, Array<Symbol, String>]
     #   grouping keys.
     # @return [SubFrames]
     #   a created SubFrames grouped by column values on `keys`.
     # @example
-    #   df.sub_by_value(keys: :y)
+    #   df.sub_by_value(:y)
     #
     #   # =>
     #   #<RedAmber::SubFrames : 0x000000000000fc08>
@@ -454,8 +454,8 @@ module RedAmber
     #
     # @since 0.4.0
     #
-    def sub_by_value(keys: nil)
-      SubFrames.new(self, group(keys).filters)
+    def sub_by_value(*keys)
+      SubFrames.new(self, group(keys.flatten).filters)
     end
     alias_method :subframes_by_value, :sub_by_value
 

--- a/lib/red_amber/data_frame.rb
+++ b/lib/red_amber/data_frame.rb
@@ -458,6 +458,7 @@ module RedAmber
       SubFrames.new(self, group(keys.flatten).filters)
     end
     alias_method :subframes_by_value, :sub_by_value
+    alias_method :sub_group, :sub_by_value
 
     # Create SubFrames by Windowing with `from`, `size` and `step`.
     #

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -267,7 +267,12 @@ module RedAmber
       when DataFrame
         agg
       when Array
-        agg.reduce { |aggregated, df| aggregated.assign(df.to_h) }
+        aggregations =
+          agg.map do |df|
+            v = df.vectors[-1]
+            [v.key, v]
+          end
+        agg[0].assign(aggregations)
       else
         raise GroupArgumentError, "Unknown argument: #{agg}"
       end

--- a/lib/red_amber/helper.rb
+++ b/lib/red_amber/helper.rb
@@ -78,6 +78,32 @@ module RedAmber
         Array(range)
       end
     end
+
+    # Create sink node and execute plan
+    #
+    # @param plan [Arrow::ExecutePlan]
+    #   Execute plan of Acero.
+    # @param node [Arrow::ExecuteNode]
+    #   Execute node of Acero.
+    # @param output_schema [Arrow::Schema, nil]
+    #   Schema of table to output. If it is nil, output_schema of
+    #   sink node is used.
+    # @return [Arrow::Table]
+    #   Result of plan.
+    # @since 0.5.0
+    #
+    def sink_and_start_plan(plan, node, output_schema: nil)
+      sink_node_options = Arrow::SinkNodeOptions.new
+      plan.build_sink_node(node, sink_node_options)
+      plan.validate
+      plan.start
+      plan.wait
+      output_schema = node.output_schema if output_schema.nil?
+      reader = sink_node_options.get_reader(output_schema)
+      table = reader.read_all
+      plan.stop
+      table
+    end
   end
 
   # rubocop:disable Layout/LineLength

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -20,6 +20,7 @@ module RedAmber
         @sizes = []
       end
 
+      # Generic iterator method
       def each
         @selectors.each
       end
@@ -27,14 +28,20 @@ module RedAmber
 
     # Boolean selectors of sub-dataframes
     class Filters < Selectors
+      # Return sizes of filter
+      # @return [Array<Integer>]
+      #   sizes of each sub dataframes.
+      #   Counts true for each filter.
       def sizes
-        # count true
         @sizes = @selectors.map { |s| s.to_a.count { _1 } } # rubocop:disable Performance/Size
       end
     end
 
     # Index selectors of sub-dataframes
     class Indices < Selectors
+      # Return sizes of selector indices.
+      # @return [Array<Integer>]
+      #   sizes of each sub dataframes.
       def sizes
         @sizes = @selectors.map(&:size)
       end

--- a/lib/red_amber/subframes.rb
+++ b/lib/red_amber/subframes.rb
@@ -93,7 +93,7 @@ module RedAmber
       # @since 0.4.0
       #
       def by_group(group)
-        SubFrames.new(group.dataframe, group.filters)
+        SubFrames.by_filters(group.dataframe, group.filters)
       end
 
       # Create a new SubFrames object from a DataFrame and an array of indices.
@@ -291,15 +291,15 @@ module RedAmber
         selectors = yield(dataframe)
       end
 
-      if dataframe.empty? || selectors.nil? || selectors.empty?
+      if dataframe.empty? || selectors.nil? || selectors.size.zero? # rubocop:disable Style/ZeroLengthPredicate
         @baseframe = DataFrame.new
         @selectors = Selectors.new([])
       else
         @baseframe = dataframe
         @selectors =
-          if selectors[0].boolean?
+          if selectors.first.boolean?
             Filters.new(selectors)
-          elsif selectors[0].numeric?
+          elsif selectors.first.numeric?
             Indices.new(selectors)
           else
             raise SubFramesArgumentError, "illegal type: #{selectors}"

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -281,11 +281,11 @@ class DataFrameTest < Test::Unit::TestCase
         ---
                 x y        z
           <uint8> <string> <boolean>
-        0       5 B        true
+        0       4 B        (nil)
         ---
                 x y        z
           <uint8> <string> <boolean>
-        0       4 B        (nil)
+        0       5 B        true
         ---
         + 1 more DataFrame.
       STR

--- a/test/test_data_frame.rb
+++ b/test/test_data_frame.rb
@@ -243,7 +243,7 @@ class DataFrameTest < Test::Unit::TestCase
     end
 
     test '#sub_by_value' do
-      sf = @df.sub_by_value(keys: :y)
+      sf = @df.sub_by_value(:y)
       assert_kind_of SubFrames, sf
       assert_equal <<~STR, sf.to_s
                 x y        z
@@ -263,10 +263,8 @@ class DataFrameTest < Test::Unit::TestCase
       STR
     end
 
-    test '#sub_by_value with multiple keys' do
-      sf = @df.sub_by_value(keys: %i[y z])
-      assert_kind_of SubFrames, sf
-      assert_equal <<~STR, sf.to_s
+    setup do
+      @expected = <<~STR
                 x y        z
           <uint8> <string> <boolean>
         0       1 A        false
@@ -289,6 +287,18 @@ class DataFrameTest < Test::Unit::TestCase
         ---
         + 1 more DataFrame.
       STR
+    end
+
+    test '#sub_by_value(key1, key2)' do
+      sf = @df.sub_by_value(:y, :z)
+      assert_kind_of SubFrames, sf
+      assert_equal @expected, sf.to_s
+    end
+
+    test '#sub_by_value([key1, key2])' do
+      sf = @df.sub_by_value(%i[y z])
+      assert_kind_of SubFrames, sf
+      assert_equal @expected, sf.to_s
     end
 
     test '#sub_by_window with size and step' do

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -193,21 +193,23 @@ class GroupTest < Test::Unit::TestCase
 
     test 'filters by a key' do
       expect = [
-        [true,  true,  false, false, false, nil],
-        [false, false, true,  false, false, nil],
-        [false, false, false, true,  true,  nil],
+        [true,  false, false, false, false, false],
+        [false, true,  false, false, false, false],
+        [false, false, false, true,  false, false],
+        [false, false, true,  false, false, false],
+        [false, false, false, false, true,  false],
         [false, false, false, false, false, true],
       ]
-      assert_equal expect, @df.group(:i).filters.map(&:to_a)
-      assert_true @df.group(:i).filters.all?(Vector)
+      assert_equal expect, @df.group(:f).filters.map(&:to_a)
+      assert_true @df.group(:f).filters.all?(Vector)
     end
 
     test 'filters by multiple keys' do
       expect = [
-        [true, false, false, false, false, nil],
+        [true, false, false, false, false, false],
         [false, true, false, false, false, false],
         [false, false, true, false, false, false],
-        [false, false, false, true, false, nil],
+        [false, false, false, true, false, false],
         [false, false, false, false, true, false],
         [false, false, false, false, false, true],
       ]

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -168,7 +168,7 @@ class GroupTest < Test::Unit::TestCase
         Vectors : 3 numeric
         # key       type   level data_preview
         0 :i        uint8      4 [0, 1, 2, nil], 1 nil
-        1 :count    int64      3 [2, 1, 2, 0]
+        1 :count    uint8      3 [2, 1, 2, 0]
         2 :"sum(f)" double     4 [1.1, 2.2, NaN, nil], 1 NaN, 1 nil
       OUTPUT
       assert_equal str, @df.group(:i) { [count(:i, :f, :b), sum] }.tdr_str(tally: 0)

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -380,6 +380,28 @@ class GroupTest < Test::Unit::TestCase
     end
   end
 
+  sub_test_case '#grouped_frame' do
+    setup do
+      @df = DataFrame.new(
+        i: [0, 0, 1, 2, 2, nil],
+        f: [0.0, 1.1, 2.2, 3.3, Float::NAN, nil],
+        s: ['A', 'B', nil, 'A', 'B', 'A'],
+        b: [true, false, true, false, true, nil]
+      )
+    end
+
+    test '#grouped_frame' do
+      group = @df.group(:s)
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 1 Vector
+        Vector : 1 string
+        # key type   level data_preview
+        0 :s  string     3 ["A", "B", nil], 1 nil
+      STR
+      assert_equal str, group.grouped_frame.tdr_str
+    end
+  end
+
   sub_test_case 'call Vector\'s aggregating function' do
     setup do
       @df = DataFrame.new(

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -216,14 +216,25 @@ class GroupTest < Test::Unit::TestCase
     end
 
     test 'group_count' do
-      str = <<~STR
+      assert_equal <<~STR, @df.group(:i).group_count.tdr_str
         RedAmber::DataFrame : 4 x 2 Vectors
         Vectors : 2 numeric
         # key          type  level data_preview
         0 :i           uint8     4 [0, 1, 2, nil], 1 nil
-        1 :group_count uint8     2 {2=>2, 1=>2}
+        1 :group_count int64     2 {2=>2, 1=>2}
       STR
-      assert_equal str, @df.group(:i).group_count.tdr_str
+    end
+
+    test 'group_count w/o nil' do
+      dataframe = DataFrame.new(x: %w[A A B B B C])
+      group = Group.new(dataframe, :x)
+      assert_equal <<~STR, group.group_count.tdr_str
+        RedAmber::DataFrame : 3 x 2 Vectors
+        Vectors : 1 numeric, 1 string
+        # key          type   level data_preview
+        0 :x           string     3 ["A", "B", "C"]
+        1 :group_count int64      3 [2, 3, 1]
+      STR
     end
 
     test 'each' do
@@ -266,12 +277,12 @@ class GroupTest < Test::Unit::TestCase
       group = @df.group(:i)
       str = <<~STR
         #<RedAmber::Group : #{format('0x%016x', group.object_id)}>
-                i   count
-          <uint8> <int64>
-        0       0       2
-        1       1       1
-        2       2       2
-        3   (nil)       0
+                i group_count
+          <uint8>     <int64>
+        0       0           2
+        1       1           1
+        2       2           2
+        3   (nil)           1
       STR
       assert_equal str, group.inspect
     end

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -193,11 +193,11 @@ class GroupTest < Test::Unit::TestCase
 
     test 'filters by a key' do
       expect = [
-        [true,  false, false, false, false, false],
-        [false, true,  false, false, false, false],
-        [false, false, false, true,  false, false],
-        [false, false, true,  false, false, false],
-        [false, false, false, false, true,  false],
+        [true,  false, false, false, false, nil],
+        [false, true,  false, false, false, nil],
+        [false, false, false, true,  false, nil],
+        [false, false, true,  false, false, nil],
+        [false, false, false, false, true,  nil],
         [false, false, false, false, false, true],
       ]
       assert_equal expect, @df.group(:f).filters.map(&:to_a)
@@ -206,10 +206,10 @@ class GroupTest < Test::Unit::TestCase
 
     test 'filters by multiple keys' do
       expect = [
-        [true, false, false, false, false, false],
+        [true, false, false, false, false, nil],
         [false, true, false, false, false, false],
         [false, false, true, false, false, false],
-        [false, false, false, true, false, false],
+        [false, false, false, true, false, nil],
         [false, false, false, false, true, false],
         [false, false, false, false, false, true],
       ]


### PR DESCRIPTION
Closes #216 .

- [x] Migrate to own Acero engine
  - `Group#filter` migrated to its own Acero engine.

- [x] Support SubFrames like syntax
  - Add syntax similar to `SubFrames#aggregate` yielding a Hash from the block in `#summarize`.

- [x] Quick initialization
  - Make initialization (natural count) and #filter quicker by whole Acero engine.
It is 2.2 times faster in mock-up test for #filter.

Support new hash_* functions
Add support for other hash_* function that is not supported in Red Arrow.
This should be ported later.