### PR TITLE
Upgrade to Arrow 12.0.0 and update DataFrame#join

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y -V libarrow-dev=11.0.0-1
-          sudo apt install -y -V gir1.2-arrow-1.0=11.0.0-1
-          sudo apt install -y -V libarrow-glib-dev=11.0.0-1
+          sudo apt install -y -V libarrow-dev
+          sudo apt install -y -V gir1.2-arrow-1.0
+          sudo apt install -y -V libarrow-glib-dev
 
       - name: Prepare Apache Arrow on macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/code_climate.yml
+++ b/.github/workflows/code_climate.yml
@@ -19,9 +19,9 @@ jobs:
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
           sudo apt update
-          sudo apt install -y -V libarrow-dev=11.0.0-1
-          sudo apt install -y -V gir1.2-arrow-1.0=11.0.0-1
-          sudo apt install -y -V libarrow-glib-dev=11.0.0-1
+          sudo apt install -y -V libarrow-dev
+          sudo apt install -y -V gir1.2-arrow-1.0
+          sudo apt install -y -V libarrow-glib-dev
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get -y install podman
-          podman pull fedora:38
+          podman pull fedora:39
       - name: Get source
         uses: actions/checkout@v3
         with:
@@ -23,7 +23,7 @@ jobs:
       - name: Create container and run tests
         run: |
           {
-              echo 'FROM fedora:38'
+              echo 'FROM fedora:39'
               echo '# set TZ to ensure the test using timestamp'
               echo 'ENV TZ=Asia/Tokyo'
               echo 'RUN dnf -y update'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Metrics/AbcSize:
   Max: 30
   CountRepeatedAttributes: false
   AllowedMethods: [
+    'join_merge_keys', # 54.18
     'join', # 51.87
     'dataframe_info', # 46.5
     'format_table', # 84.62
@@ -140,11 +141,12 @@ Metrics/MethodLength:
   Max: 30
   AllowedMethods: [
     'join', # 47
-    'dataframe_info', # 33
+    'join_merge_keys', # 41
     'format_table', # 53
     'slice_by', # 38
     'assign_update', # 35
     'summarize', # 35
+    'dataframe_info', # 33
     'drop', # 32
     'aggregate', # 31
   ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,7 +77,7 @@ Metrics/AbcSize:
   CountRepeatedAttributes: false
   AllowedMethods: [
     'join_merge_keys', # 54.18
-    'join', # 51.87
+    'join', # 53.1
     'dataframe_info', # 46.5
     'format_table', # 84.62
     'to_long', # 33.66
@@ -89,6 +89,8 @@ Metrics/AbcSize:
     'split', # 37.35
     'aggregate', # 38.13
     'filters', # 33.91
+    'merge_keys', # 32.17
+    'rename_keys', # 31.64
   ]
 
 # Max: 25

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake'
 
-  gem 'red-parquet', '~> 11.0.0'
+  gem 'red-parquet', '~> 12.0.0'
   gem 'rover-df', '~> 0.3.0'
 
   gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ A simple dataframe library for Ruby.
 ## Requirements
 ### Ruby
 Supported Ruby version is >= 3.0 (since RedAmber 0.3.0).
-- I decided to remove support for Ruby 2.7 without waiting for its EOL. See [Release note for v0.3.0](https://github.com/red-data-tools/red_amber/discussions/162) for details.
 
-### Libraries
+### Required libraries
 ```ruby
-gem 'red-arrow',   '~> 11.0.0' # Requires Apache Arrow (see installation below)
-gem 'red-parquet', '~> 11.0.0' # Optional, if you use IO from/to parquet
-gem 'red-datasets-arrow'       # Optional, if you use random sampling
+gem 'red-arrow',   '~> 12.0.0' # Requires Apache Arrow (see installation below)
+gem 'red-parquet', '~> 12.0.0' # Optional, if you use IO from/to parquet
+gem 'red-datasets-arrow'       # Optional, if you use Red Datasets or random sampling feature
+gem 'red-arrow-activerecord'   # Optional, if you use Active Record
 gem 'rover-df',    '~> 0.3.0'  # Optional, if you use IO from/to Rover::DataFrame
 ```
 
@@ -32,9 +32,9 @@ gem 'rover-df',    '~> 0.3.0'  # Optional, if you use IO from/to Rover::DataFram
 
 Install requirements before you install RedAmber.
 
-- Apache Arrow (~> 11.0.0)
-- Apache Arrow GLib (~> 11.0.0)
-- Apache Parquet GLib (~> 11.0.0)  # If you use IO from/to parquet
+- Apache Arrow (~> 12.0.0)
+- Apache Arrow GLib (~> 12.0.0)
+- Apache Parquet GLib (~> 12.0.0)  # If you use IO from/to parquet
 
 See [Apache Arrow install document](https://arrow.apache.org/install/).
   
@@ -67,9 +67,9 @@ See [Apache Arrow install document](https://arrow.apache.org/install/).
 If you prepared Apache Arrow, add these lines to your Gemfile:
 
 ```ruby
-gem 'red-arrow',   '~> 11.0.0'
+gem 'red-arrow',   '~> 12.0.0'
 gem 'red_amber'
-gem 'red-parquet', '~> 11.0.0' # Optional, if you use IO from/to parquet
+gem 'red-parquet', '~> 12.0.0' # Optional, if you use IO from/to parquet
 gem 'rover-df',    '~> 0.3.0'  # Optional, if you use IO from/to Rover::DataFrame
 gem 'red-datasets-arrow'       # Optional, recommended if you use Red Datasets
 gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [Apache Arrow install document](https://arrow.apache.org/install/).
       sudo apt install -y -V libarrow-glib-dev
       ```
 
-  - On Fedora 38 (Rawhide):
+  - On Fedora 39 (Rawhide):
 
       ```
       sudo dnf update

--- a/docker/Gemfile
+++ b/docker/Gemfile
@@ -5,9 +5,9 @@ source 'https://rubygems.org'
 gem 'irb'
 
 gem 'numo-narray'
-gem 'red-arrow', '~> 11.0.0'
+gem 'red-arrow', '~> 12.0.0'
 gem 'red-arrow-numo-narray'
-gem 'red-parquet', '~> 11.0.0'
+gem 'red-parquet', '~> 12.0.0'
 
 gem 'red_amber', path: '../'
 gem 'red-amber-view'

--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     red_amber (0.5.0.pre.HEAD)
-      red-arrow (~> 11.0.0)
+      red-arrow (~> 12.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -24,18 +24,18 @@ GEM
     faker (3.1.1)
       i18n (>= 1.8.11, < 2)
     fiddle (1.1.1)
-    gio2 (4.1.2)
+    gio2 (4.1.4)
       fiddle
-      gobject-introspection (= 4.1.2)
-    glib2 (4.1.2)
+      gobject-introspection (= 4.1.4)
+    glib2 (4.1.4)
       native-package-installer (>= 1.0.3)
       pkg-config (>= 1.3.5)
-    gobject-introspection (4.1.2)
-      glib2 (= 4.1.2)
+    gobject-introspection (4.1.4)
+      glib2 (= 4.1.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
-    irb (1.6.3)
+    irb (1.6.4)
       reline (>= 0.3.0)
     libui (0.0.15)
     matplotlib (1.3.0)
@@ -52,7 +52,7 @@ GEM
       numpy
       pycall (>= 1.0.0)
     pkg-config (1.5.1)
-    playwright-ruby-client (1.32.0)
+    playwright-ruby-client (1.31.1)
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
     pycall (1.4.2)
@@ -60,7 +60,7 @@ GEM
       libui
       red-arrow
       red_amber
-    red-arrow (11.0.0)
+    red-arrow (12.0.0)
       bigdecimal (>= 3.1.0)
       extpp (>= 0.1.1)
       gio2 (>= 3.5.0)
@@ -80,9 +80,9 @@ GEM
       red-datasets (>= 0.0.3)
     red-palette (0.5.0)
       red-colors (>= 0.3.0)
-    red-parquet (11.0.0)
-      red-arrow (= 11.0.0)
-    reline (0.3.2)
+    red-parquet (12.0.0)
+      red-arrow (= 12.0.0)
+    reline (0.3.3)
       io-console (~> 0.5)
     rexml (3.2.5)
     rover-df (0.3.4)
@@ -92,6 +92,7 @@ GEM
       enumerable-statistics (>= 2.0.1)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -104,11 +105,11 @@ DEPENDENCIES
   numo-narray
   pycall
   red-amber-view
-  red-arrow (~> 11.0.0)
+  red-arrow (~> 12.0.0)
   red-arrow-numo-narray
   red-datasets
   red-datasets-arrow
-  red-parquet (~> 11.0.0)
+  red-parquet (~> 12.0.0)
   red_amber!
   rover-df
   unicode_plot

--- a/lib/red_amber/data_frame_combinable.rb
+++ b/lib/red_amber/data_frame_combinable.rb
@@ -221,6 +221,11 @@ module RedAmber
     # - Same as `#join` with `type: :inner`
     # - A kind of mutating join.
     #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
+    #
     # @overload inner_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
     #   (natural keys). Returns joined dataframe.
@@ -279,6 +284,11 @@ module RedAmber
     # Join another DataFrame or Table, leaving all records.
     # - Same as `#join` with `type: :full_outer`
     # - A kind of mutating join.
+    #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
     #
     # @overload full_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
@@ -348,6 +358,11 @@ module RedAmber
     # - Same as `#join` with `type: :left_outer`
     # - A kind of mutating join.
     #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
+    #
     # @overload left_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
     #   (natural keys). Returns joined dataframe.
@@ -410,6 +425,11 @@ module RedAmber
     # - Same as `#join` with `type: :right_outer`
     # - A kind of mutating join.
     #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
+    #
     # @overload right_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
     #   (natural keys). Returns joined dataframe.
@@ -422,11 +442,11 @@ module RedAmber
     #     df.right_join(other)
     #
     #     # =>
-    #       KEY           X1 X2
-    #       <string> <uint8> <boolean>
-    #     0 A              1 true
-    #     1 B              2 false
-    #     2 D          (nil) (nil)
+    #            X1 KEY      X2
+    #       <uint8> <string> <boolean>
+    #     0       1 A        true
+    #     1       2 B        false
+    #     2   (nil) D        (nil)
     #
     # @overload right_join(other, join_keys, suffix: '.1', force_order: true)
     #
@@ -439,11 +459,11 @@ module RedAmber
     #     df.right_join(other, :KEY)
     #
     #     # =>
-    #       KEY           X1 X2
-    #       <string> <uint8> <boolean>
-    #     0 A              1 true
-    #     1 B              2 false
-    #     2 D          (nil) (nil)
+    #            X1 KEY      X2
+    #       <uint8> <string> <boolean>
+    #     0       1 A        true
+    #     1       2 B        false
+    #     2   (nil) D        (nil)
     #
     # @overload right_join(other, join_key_pairs, suffix: '.1', force_order: true)
     #
@@ -456,11 +476,11 @@ module RedAmber
     #     df2.right_join(other2, { left: :KEY1, right: :KEY2 })
     #
     #     # =>
-    #       KEY1          X1 X2
-    #       <string> <uint8> <boolean>
-    #     0 A              1 true
-    #     1 B              2 false
-    #     2 D          (nil) (nil)
+    #             X1 KEY2     X2
+    #       <uint8> >string> <boolean>
+    #     0        1 A        true
+    #     1        2 B        false
+    #     2    (nil) D        (nil)
     #
     # @since 0.2.3
     #
@@ -479,6 +499,11 @@ module RedAmber
     # Return records of self that have a match in other.
     # - Same as `#join` with `type: :left_semi`
     # - A kind of filtering join.
+    #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
     #
     # @overload semi_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
@@ -538,6 +563,11 @@ module RedAmber
     # Return records of self that do not have a match in other.
     # - Same as `#join` with `type: :left_anti`
     # - A kind of filtering join.
+    #
+    # @note the order of joined results will be preserved by default.
+    #   This is enabled by appending index column to sort after joining but
+    #   it will cause some performance degradation. If you don't matter
+    #   the order of the result, set `force_order` option to `false`.
     #
     # @overload anti_join(other, suffix: '.1', force_order: true)
     #   If `join_key` is not specified, common keys in self and other are used
@@ -661,7 +691,7 @@ module RedAmber
         raise DataFrameArgumentError, 'keys are not same with self and other'
       end
 
-      join(other, keys, type: :full_outer)
+      join(other, keys, type: :full_outer, force_order: true)
     end
 
     # Select records appearing in self but not in other.
@@ -733,12 +763,12 @@ module RedAmber
     #     1 B        E
     #     2 C        F
 
-    # @note the order of joined results will be preserved by default.
-    #   This is enabled by appending index column to sort after joining but
-    #   it will cause some performance degradation. If you don't matter
-    #   the order of the result, set `force_order` option to `false`.
+    # @note the order of joined results may not be preserved by default.
+    #   if you prefer to preserve the order of the result, set `force_order` option
+    #   to `true`. This is enabled by appending index column to sort after joining
+    #   so it will cause some performance degradation.
     #
-    # @overload join(other, type: :inner, suffix: '.1', force_order: true)
+    # @overload join(other, type: :inner, suffix: '.1', force_order: false)
     #
     #   If `join_key` is not specified, common keys in self and other are used
     #   (natural keys). Returns joined dataframe.
@@ -767,7 +797,7 @@ module RedAmber
     #     2 C              3 (nil)
     #     3 D          (nil) (nil)
     #
-    # @overload join(other, join_keys, type: :inner, suffix: '.1', force_order: true)
+    # @overload join(other, join_keys, type: :inner, suffix: '.1', force_order: false)
     #
     #   @macro join_before
     #   @macro join_key_in_array
@@ -792,7 +822,8 @@ module RedAmber
     #     0 A              1       1
     #     1 B              2       4
     #
-    # @overload join(other, join_key_pairs, type: :inner, suffix: '.1', force_order: true)
+    # @overload join(
+    #   other, join_key_pairs, type: :inner, suffix: '.1', force_order: false)
     #
     #   @macro join_before
     #   @macro join_key_in_hash
@@ -828,7 +859,8 @@ module RedAmber
     #
     # @since 0.2.3
     #
-    def join(other, join_keys = nil, type: :inner, suffix: '.1', force_order: true)
+    def join(other, join_keys = nil, type: :inner, suffix: '.1', force_order: false)
+      left_table = table
       right_table =
         case other
         when DataFrame
@@ -839,24 +871,26 @@ module RedAmber
           raise DataFrameArgumentError, 'other must be a DataFrame or an Arrow::Table'
         end
 
-      type = type.to_sym
-      left_index = :__LEFT_INDEX__
-      right_index = :__RIGHT_INDEX__
       if force_order
+        left_index = :__LEFT_INDEX__
+        right_index = :__RIGHT_INDEX__
         left_table = assign(left_index) { indices }.table
         other = DataFrame.create(other) if other.is_a?(Arrow::Table)
         right_table = other.assign(right_index) { indices }.table
-      else
-        left_table = table
       end
 
-      table_keys = left_table.keys
-      other_keys = right_table.keys
-
+      left_table_keys = ensure_keys(left_table.keys)
+      right_table_keys = ensure_keys(right_table.keys)
       # natural keys (implicit common keys)
-      join_keys ||= table_keys.intersection(other_keys)
+      join_keys ||= left_table_keys.intersection(right_table_keys)
 
-      # This is not necessary if additional procedure is contributed to Red Arrow.
+      type = Arrow::JoinType.try_convert(type) || type
+      type_nick = type.nick
+
+      plan = Arrow::ExecutePlan.new
+      left_node = plan.build_source_node(left_table)
+      right_node = plan.build_source_node(right_table)
+
       if join_keys.is_a?(Hash)
         left_keys = ensure_keys(join_keys[:left])
         right_keys = ensure_keys(join_keys[:right])
@@ -865,95 +899,100 @@ module RedAmber
         right_keys = left_keys
       end
 
-      case type
-      when :full_outer, :left_semi, :left_anti, :right_semi, :right_anti
-        left_outputs = nil
-        right_outputs = nil
-      when :inner, :left_outer
-        left_outputs = table_keys
-        right_outputs = other_keys - right_keys
-      when :right_outer
-        left_outputs = table_keys - left_keys
-        right_outputs = other_keys
+      hash_join_node_options = Arrow::HashJoinNodeOptions.new(type, left_keys, right_keys)
+      case type.nick
+      when 'inner', 'left-outer'
+        hash_join_node_options.left_outputs = left_table_keys
+        hash_join_node_options.right_outputs = right_table_keys - right_keys
+      when 'right-outer'
+        hash_join_node_options.left_outputs = left_table_keys - left_keys
+        hash_join_node_options.right_outputs = right_table_keys
       end
 
-      # Should we rescue errors in Arrow::Table#join for usability ?
-      joined_table =
-        left_table.join(
-          right_table,
-          join_keys,
-          type: type,
-          left_outputs: left_outputs,
-          right_outputs: right_outputs
-        )
-
-      case type
-      when :inner, :left_outer, :left_semi, :left_anti, :right_semi, :right_anti
-        dataframe =
-          if joined_table.keys.uniq!
-            DataFrame.create(rename_table(joined_table, n_keys, suffix))
-          else
-            DataFrame.create(joined_table)
-          end
-        sorter =
-          case type
-          when :inner, :left_outer
-            [left_index, right_index]
-          when :left_semi, :left_anti
-            [left_index]
-          when :right_semi, :right_anti
-            [right_index]
-          end
-      when :full_outer
-        key_index_lr =
-          left_keys.map { left_table.keys.index(_1) }
-            .zip(right_keys.map { left_table.keys.size + right_table.keys.index(_1) })
-        renamed_table = rename_table(joined_table, n_keys, suffix)
-        dropper = []
-        dataframe =
-          DataFrame.create(renamed_table).assign do |df|
-            key_index_lr.map do |l, r|
-              dropper << df.keys[r]
-              [df.keys[l], merge_array(df.vectors[l].data, df.vectors[r].data)]
-            end
-          end
-        dataframe = dataframe.drop(dropper)
-        sorter = [left_index, right_index]
-      when :right_outer
-        dataframe =
-          if joined_table.keys.uniq!
-            DataFrame.create(rename_table(joined_table, left_outputs.size, suffix))
-          else
-            DataFrame.create(joined_table)
-          end
-        dataframe = dataframe.pick(right_keys, dataframe.keys - right_keys)
-        sorter = [left_index, right_index]
+      hash_join_node =
+        plan.build_hash_join_node(left_node, right_node, hash_join_node_options)
+      merge_node =
+        if type_nick == 'full-outer'
+          merge_join_key_node(plan, hash_join_node,
+                              left_table_keys, right_table_keys,
+                              left_keys, right_keys)
+        else
+          hash_join_node
+        end
+      joined_table = sink_and_start_plan(plan, merge_node)
+      if joined_table.keys.uniq!
+        joined_table =
+          rename_table(joined_table, left_table_keys, right_table_keys, type_nick, suffix)
       end
 
+      df = DataFrame.create(joined_table)
       if force_order
-        dataframe
-          .sort(sorter)
+        sorter =
+          case type_nick
+          when 'right-semi', 'right-anti'
+            [right_index]
+          when 'left-semi', 'left-anti'
+            [left_index]
+          else
+            [left_index, right_index]
+          end
+        df.sort(sorter)
           .drop(sorter)
       else
-        dataframe
+        df
       end
     end
 
     private
 
-    # To ensure Array of Symbols
+    # To ensure Array of Strings
     def ensure_keys(keys)
-      Array(keys).map(&:to_sym)
+      Array(keys).map(&:to_s)
     end
 
-    # Rename duplicate keys by suffix
-    def rename_table(joined_table, n_keys, suffix)
-      joined_keys = joined_table.keys
-      other_keys = joined_keys[n_keys..]
+    # Merge key columns and preserve as left and remove right.
+    def merge_join_key_node(plan, input_node,
+                            left_table_keys, right_table_keys,
+                            left_keys, right_keys)
+      left_indices = left_keys.map { left_table_keys.index(_1) }
+      right_offset = left_table_keys.size
+      right_indices = right_keys.map { right_table_keys.index(_1) + right_offset }
+      expressions = []
+      names = []
+      left_table_keys.each_with_index do |key, index|
+        names << key
+        expressions <<
+          if (i = left_indices.index(index))
+            left_field = Arrow::FieldExpression.new("[#{left_indices[i]}]")
+            right_field = Arrow::FieldExpression.new("[#{right_indices[i]}]")
+            is_left_null = Arrow::CallExpression.new('is_null', [left_field])
+            Arrow::CallExpression.new('if_else', [is_left_null, right_field, left_field])
+          else
+            Arrow::FieldExpression.new("[#{index}]")
+          end
+      end
+      right_table_keys.each.with_index(right_offset) do |key, index|
+        unless right_indices.include?(index)
+          names << key
+          expressions << Arrow::FieldExpression.new("[#{index}]")
+        end
+      end
+      project_node_options = Arrow::ProjectNodeOptions.new(expressions, names)
+      plan.build_project_node(input_node, project_node_options)
+    end
 
+    def rename_table(joined_table, left_table_keys, right_table_keys, type_nick, suffix)
+      joined_keys = joined_table.keys
+      pos_rights =
+        if type_nick.start_with?('right')
+          joined_keys.size - right_table_keys.size
+        else
+          left_table_keys.size
+        end
+      rights = joined_keys[pos_rights..]
       dup_keys = joined_keys.tally.select { |_, v| v > 1 }.keys
       renamed_right_keys =
-        other_keys.map do |key|
+        rights.map do |key|
           if dup_keys.include?(key)
             suffixed = "#{key}#{suffix}".to_sym
             # Find a key from suffixed.succ
@@ -962,19 +1001,13 @@ module RedAmber
             key
           end
         end
-      joined_keys[n_keys..] = renamed_right_keys
+      joined_keys[pos_rights..] = renamed_right_keys
 
       fields =
         joined_keys.map.with_index do |k, i|
           Arrow::Field.new(k, joined_table[i].data_type)
         end
       Arrow::Table.new(Arrow::Schema.new(fields), joined_table.columns)
-    end
-
-    # Merge two Arrow::Arrays
-    def merge_array(array1, array2)
-      t = Arrow::Function.find(:is_null).execute([array1])
-      Arrow::Function.find(:if_else).execute([t, array2, array1]).value
     end
   end
 end

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '~> 11.0.0'
+  spec.add_dependency 'red-arrow', '~> 12.0.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)
 

--- a/test/test_data_frame_combinable.rb
+++ b/test/test_data_frame_combinable.rb
@@ -221,8 +221,8 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
 
       test '#right_join with a join_key)' do
         expected = DataFrame.new(
-          KEY: %w[A B D],
           X: [1, 2, nil],
+          KEY: %w[A B D],
           Y: [3, 2, 1]
         )
         assert_equal expected, @df1.right_join(@right1) # natural join
@@ -398,9 +398,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
 
       test '#right_join with join_keys' do
         expected = DataFrame.new(
+          X: [1, nil, nil],
           KEY1: %w[A B D],
           KEY2: %w[s u v],
-          X: [1, nil, nil],
           Y: [3, 2, 1]
         )
         assert_equal expected, @df2.right_join(@right2) # natural join
@@ -419,10 +419,10 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
 
       test '#right_join with join_keys, partial join_key/rename' do
         expected = DataFrame.new(
-          KEY2: %w[s u v],
           KEY1: ['A', 'C', nil],
           X: [1, 3, nil],
           'KEY1.1': %w[A B D],
+          KEY2: %w[s u v],
           Y: [3, 2, 1]
         )
         assert_equal expected, @df2.right_join(@right2, :KEY2)
@@ -527,9 +527,9 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
 
       test '#right_join with rename and collision by default' do
         expected = DataFrame.new(
-          'KEY.1': %w[A B D],
           KEY: ['s', 't', nil],
           X: [1, 2, nil],
+          'KEY.1': %w[A B D],
           'KEY.2': %w[s u v],
           Y: [3, 2, 1]
         )
@@ -551,22 +551,46 @@ class DataFrameDisplayableTest < Test::Unit::TestCase
     end
 
     sub_test_case 'sort by :force_order' do
-      test '#full_join w/o sort' do
+      test '#full_join w/ sort' do
         sort = @df2.full_join(@right2, :KEY2, force_order: true)
         no_sort = @df2.full_join(@right2, :KEY2, force_order: false)
-        assert_equal_dataframe_by_hash(sort, no_sort)
+        assert_equal_dataframe_non_order(sort, no_sort)
       end
 
-      test '#left_join w/o sort' do
+      test '#left_join w/ sort' do
         sort = @df2.left_join(@right2, :KEY2, force_order: true)
         no_sort = @df2.left_join(@right2, :KEY2, force_order: false)
-        assert_equal_dataframe_by_hash(sort, no_sort)
+        assert_equal_dataframe_non_order(sort, no_sort)
       end
 
-      test '#right_join w/o sort' do
+      test '#right_join w/ sort' do
         sort = @df2.right_join(@right2, :KEY2, force_order: true)
         no_sort = @df2.right_join(@right2, :KEY2, force_order: false)
-        assert_equal_dataframe_by_hash(sort, no_sort)
+        assert_equal_dataframe_non_order(sort, no_sort)
+      end
+
+      test '#left_semi w/ sort' do
+        sort = @df2.join(@right2, :KEY2, type: :left_semi, force_order: true)
+        no_sort = @df2.join(@right2, :KEY2, type: :left_semi, force_order: false)
+        assert_equal_dataframe_non_order(sort, no_sort)
+      end
+
+      test '#left_anti w/ sort' do
+        sort = @df2.join(@right2, :KEY2, type: :left_anti, force_order: true)
+        no_sort = @df2.join(@right2, :KEY2, type: :left_anti, force_order: false)
+        assert_equal_dataframe_non_order(sort, no_sort)
+      end
+
+      test '#right_semi w/ sort' do
+        sort = @df2.join(@right2, :KEY2, type: :right_semi, force_order: true)
+        no_sort = @df2.join(@right2, :KEY2, type: :right_semi, force_order: false)
+        assert_equal_dataframe_non_order(sort, no_sort)
+      end
+
+      test '#right_anti w/ sort' do
+        sort = @df2.join(@right2, :KEY2, type: :right_anti, force_order: true)
+        no_sort = @df2.join(@right2, :KEY2, type: :right_anti, force_order: false)
+        assert_equal_dataframe_non_order(sort, no_sort)
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ module TestHelper
     end
   end
 
-  def assert_equal_dataframe_by_hash(expected, actual, message = nil)
+  def assert_equal_dataframe_non_order(expected, actual, message = nil)
     exp = expected.keys.map { |k| { k => expected[k].tally } }
     act = actual.keys.map { |k| { k => actual[k].tally } }
     assert_equal(exp, act, message)


### PR DESCRIPTION
This PR will upgrade dependency to Arrow 12.0.0 and update join method.

## Upgrade to Arrow 12.0.0

Arrow 12.0.0 includes updated Table#join method. This is updated to merge columns of join keys and introduced renaming capability.

## Update DataFrame#join

I originally planned to use join in the updated Arrow table in 12.0.0, but the table and dataframe specifications are quite different, so I decided to implement our own join in RedAmber.

`DataFrame#join` in this version is upgraded to use Acero to merge columns and to rename column names.

## Breaking change

- `right_join` will output columns as same order as Red Arrow. The join key columns were at leftmost in RedAmber 0.4.2 .
- `DataFrame#join` will not force ordering of original column by default (force_order: false, this will be same behavior as SQL which needs order_by after join). On the other hand, join methods with type, such as `inner_join` or `full_join`, sort after join by default (force_order: true, this guarantees deterministic output, as in many traditional data frames).
- Used Fedra 39 (Rawhide) which includes libarrow 12.0.0-1.fc39 in CI.
  [(https://packages.fedoraproject.org/pkgs/libarrow/libarrow-devel/fedora-rawhide.html)](https://packages.fedoraproject.org/pkgs/libarrow/libarrow-devel/)