### PR TITLE
Update Vector#index method

### DIFF
--- a/lib/red_amber/vector_selectable.rb
+++ b/lib/red_amber/vector_selectable.rb
@@ -153,10 +153,23 @@ module RedAmber
     # @param element
     #   an element of self.
     # @return [integer, nil]
-    #   founded position of element. If it is not found, returns nil.
+    #   position of element. If it is not found, returns nil.
     #
     def index(element)
-      (0...size).find { |i| self[i] == element }
+      if element.nil?
+        datum = find(:is_null).execute([data])
+        value = Arrow::Scalar.resolve(true, :boolean)
+      else
+        datum = data
+        value = Arrow::Scalar.resolve(element, type)
+      end
+      datum = find(:index).execute([datum], value: value)
+      index = get_scalar(datum)
+      if index.negative?
+        nil
+      else
+        index
+      end
     end
 
     # Returns first element of self.

--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -187,10 +187,20 @@ class VectorTest < Test::Unit::TestCase
 
   sub_test_case '#index' do
     vector = Vector.new([1, 2, 3, nil])
+
     test 'find index' do
       assert_equal 1, vector.index(2)
+    end
+
+    test 'find index for nil' do
       assert_equal 3, vector.index(nil)
+    end
+
+    test 'index not found' do
       assert_nil vector.index(0) # out of range
+    end
+
+    test 'find index for casted scalar' do
       assert_equal 1, vector.index(2.0) # types are ignored
     end
   end


### PR DESCRIPTION
## Update Vector#index method

IndexOptions has supported in Red Arrow 12.0.0 . We can update Vector#index which is implemented in pure Ruby.

### Difference in specification with Arrow

- `Vector#index` will return nil if no match is found (returns -1 in Arrow).
- We can match with `nil` in `Vector#index` (cannot match in Arrow).
