### PR TITLE
Add Vector#find_substring method

### DIFF
--- a/test/test_vector_string_functiion.rb
+++ b/test/test_vector_string_functiion.rb
@@ -27,26 +27,26 @@ class VectorTest < Test::Unit::TestCase
       assert_equal_array expected, @vector.match_substring(/arr/i)
     end
 
-    test '#match_substring?(regexp, ignore_case: true)' do
+    test '#match_substring(regexp, ignore_case: true)' do
       expected = [true, true, true, nil, false]
       assert_equal_array expected, @vector.match_substring(/arr/, ignore_case: true)
     end
 
-    test '#match_substring? w/ illegal argument' do
+    test '#match_substring w/ illegal argument' do
       assert_raise(VectorArgumentError) { @vector.match_substring(nil) }
     end
 
-    test '#end_with?(string)' do
+    test '#end_with(string)' do
       expected = [false, true, false, nil, true]
       assert_equal_array expected, @vector.end_with('ow')
     end
 
-    test '#start_with?(string)' do
+    test '#start_with(string)' do
       expected = [false, false, true, nil, false]
       assert_equal_array expected, @vector.start_with('ca')
     end
 
-    test '#match_like?(string)' do
+    test '#match_like(string)' do
       expected = [true, true, false, nil, false]
       assert_equal_array expected, @vector.match_like('_rr%')
     end
@@ -61,8 +61,23 @@ class VectorTest < Test::Unit::TestCase
       assert_equal_array expected, @vector2.count_substring(/a[mn]/i)
     end
 
-    test '#count_substring? w/ illegal argument' do
+    test '#count_substring w/ illegal argument' do
       assert_raise(VectorArgumentError) { @vector2.count_substring(nil) }
+    end
+
+    test '#find_substring(string)' do
+      expected = [0, -1, 1, nil, -1]
+      assert_equal_array expected, @vector.find_substring('arr')
+    end
+
+    test '#find_substring(regexp) case ignored' do
+      expected = [0, 0, 1, nil, -1]
+      assert_equal_array expected, @vector.find_substring(/arr/i)
+      assert_equal_array expected, @vector.find_substring(/arr/, ignore_case: true)
+    end
+
+    test '#find_substring w/ illegal argument' do
+      assert_raise(VectorArgumentError) { @vector.find_substring(nil) }
     end
   end
 end


### PR DESCRIPTION
Closes #246 .

Find first occurrence of substring in string Vector. It overloads these both parameters.

- find_substring(string, ignore_case: nil)
  Emit the index in bytes of the first occurrence of the given literal pattern, or -1 if not found.
  It calls `find_substring()` kernel in Arrow compute function.

- find_substring(regexp, ignore_case: nil)
  Emit the index in bytes of the first occurrence of the given regexp pattern, or -1 if not found.
  It calls `find_substring_regex()` in Arrow compute function and uses re2 library.