### PR TITLE
Add missing test in Vector#rank to cover illegal rank option

### DIFF
--- a/test/test_vector_selectable.rb
+++ b/test/test_vector_selectable.rb
@@ -296,6 +296,10 @@ class VectorTest < Test::Unit::TestCase
     test '#rank chunkedarray as input' do
       assert_equal_array [2, 1, 6, 5, 4, 3], chunked.rank
     end
+
+    test '#rank illegal order option' do
+      assert_raise(VectorArgumentError) { float.rank('*') }
+    end
   end
 
   sub_test_case '#sample' do


### PR DESCRIPTION
This PR will add missing test in Vector#rank to cover illegal rank option error.

Related to #264 .