### PR TITLE
Add methods for group

### DIFF
--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -185,6 +185,23 @@ module RedAmber
     #
     define_group_aggregation :min
 
+    # Get one value from each group.
+    #
+    # @!method one(*group_keys)
+    #   @macro group_aggregation
+    #   @example
+    #     dataframe.group(:y).one
+    #
+    #     # =>
+    #     #<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000002885c>
+    #       y         one(x)
+    #       <string> <uint8>
+    #     0 A              1
+    #     1 B              3
+    #     2 C              6
+    #
+    define_group_aggregation :one
+
     # Compute product of values in each group for numeric columns.
     #
     # @!method product(*group_keys)

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -203,6 +203,31 @@ module RedAmber
     #
     define_group_aggregation :mean
 
+    # Compute median of values in each group for numeric columns.
+    #
+    # @!method median(*group_keys)
+    #   @macro group_aggregation
+    #   @example
+    #     dataframe.group(:y).median
+    #
+    #     # =>
+    #     #<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000138a8>
+    #       y        median(x)
+    #       <string>  <double>
+    #     0 A              1.5
+    #     1 B              4.0
+    #     2 C              6.0
+    #
+    define_group_aggregation :approximate_median
+    def median(*group_keys)
+      df = approximate_median(*group_keys)
+      df.rename do
+        keys_org = keys.select { _1.start_with?('approximate_') }
+        keys_renamed = keys_org.map { _1.to_s.delete_prefix('approximate_') }
+        keys_org.zip keys_renamed
+      end
+    end
+
     # Compute minimum of values in each group for numeric columns.
     #
     # @!method min(*group_keys)

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -191,6 +191,31 @@ module RedAmber
     end
     alias_method :count_all, :group_count
 
+    # Count the unique values in each group.
+    #
+    # @!method count_uniq(*group_keys)
+    # @macro group_aggregation
+    # @example Show counts for each group.
+    #   dataframe.group(:y).count_uniq
+    #
+    #   # =>
+    #   #<RedAmber::DataFrame : 3 x 3 Vectors, 0x000000000011ea04>
+    #     y        count_uniq(x) count_uniq(z)
+    #     <string>       <int64>       <int64>
+    #   0 A                    2             2
+    #   1 B                    3             3
+    #   2 C                    1             1
+    #
+    define_group_aggregation :count_distinct
+    def count_uniq(*group_keys)
+      df = count_distinct(*group_keys)
+      df.rename do
+        keys_org = keys.select { _1.start_with?('count_distinct') }
+        keys_renamed = keys_org.map { _1.to_s.gsub('distinct', 'uniq') }
+        keys_org.zip keys_renamed
+      end
+    end
+
     # Compute maximum of values in each group for numeric columns.
     #
     # @!method max(*group_keys)

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -169,6 +169,28 @@ module RedAmber
       end
     end
 
+    # Returns each record group size as a DataFrame.
+    #
+    # @return [DataFrame]
+    #   DataFrame consists of:
+    #   - Group key columns.
+    #   - Result columns by group aggregation.
+    # @example
+    #   penguins.group(:species).group_count
+    #
+    #   # =>
+    #   #<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000003a70>
+    #     species   group_count
+    #     <string>      <uint8>
+    #   0 Adelie            152
+    #   1 Chinstrap          68
+    #   2 Gentoo            124
+    #
+    def group_count
+      DataFrame.create(group_table)
+    end
+    alias_method :count_all, :group_count
+
     # Compute maximum of values in each group for numeric columns.
     #
     # @!method max(*group_keys)
@@ -389,27 +411,6 @@ module RedAmber
         yield @dataframe.filter(filter)
       end
       @filters.size
-    end
-
-    # Returns each record group size as a DataFrame.
-    #
-    # @return [DataFrame]
-    #   DataFrame consists of:
-    #   - Group key columns.
-    #   - Result columns by group aggregation.
-    # @example
-    #   penguins.group(:species).group_count
-    #
-    #   # =>
-    #   #<RedAmber::DataFrame : 3 x 2 Vectors, 0x0000000000003a70>
-    #     species   group_count
-    #     <string>      <uint8>
-    #   0 Adelie            152
-    #   1 Chinstrap          68
-    #   2 Gentoo            124
-    #
-    def group_count
-      DataFrame.create(group_table)
     end
 
     # String representation of self.

--- a/lib/red_amber/group.rb
+++ b/lib/red_amber/group.rb
@@ -80,6 +80,41 @@ module RedAmber
     #   @return [DataFrame]
     #     aggregated DataFrame
 
+    # Whether all elements in each group evaluate to true.
+    #
+    # @!method all(*group_keys)
+    #   @macro group_aggregation
+    #   @example For boolean columns by default.
+    #
+    #     dataframe.group(:y).all
+    #
+    #     # =>
+    #     #<RedAmber::DataFrame : 3 x 2 Vectors, 0x000000000000fc08>
+    #       y        all(z)
+    #       <string> <boolean>
+    #     0 A        false
+    #     1 B        false
+    #     2 C        false
+    #
+    define_group_aggregation :all
+
+    # Whether any elements in each group evaluate to true.
+    #
+    # @!method any(*group_keys)
+    #   @macro group_aggregation
+    #   @example For boolean columns by default.
+    #     dataframe.group(:y).any
+    #
+    #     # =>
+    #     #<RedAmber::DataFrame : 3 x 2 Vectors, 0x00000000000117ec>
+    #       y        any(z)
+    #       <string> <boolean>
+    #     0 A        true
+    #     1 B        true
+    #     2 C        false
+    #
+    define_group_aggregation :any
+
     # Count the number of non-nil values in each group.
     #   If counts are the same (and do not include NaN or nil),
     #   columns for counts are unified.

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -95,6 +95,17 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, group.count_all.tdr_str
     end
 
+    test 'group count_uniq' do
+      assert_equal <<~STR, @df.group(:s).count_uniq.tdr_str(tally: 0)
+        RedAmber::DataFrame : 3 x 3 Vectors
+        Vectors : 2 numeric, 1 string
+        # key              type   level data_preview
+        0 :s               string     3 ["A", "B", nil], 1 nil
+        1 :"count_uniq(i)" int64      2 [2, 2, 1]
+        2 :"count_uniq(f)" int64      2 [2, 2, 1]
+      STR
+    end
+
     test 'group count with multiple keys and aggregation' do
       str = <<~STR
         RedAmber::DataFrame : 6 x 3 Vectors

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -69,6 +69,32 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, df.group(:i).count.tdr_str(tally: 0)
     end
 
+    test 'group group_count' do
+      str = <<~STR
+        RedAmber::DataFrame : 4 x 2 Vectors
+        Vectors : 2 numeric
+        # key          type  level data_preview
+        0 :i           uint8     4 [0, 1, 2, nil], 1 nil
+        1 :group_count int64     2 {2=>2, 1=>2}
+      STR
+      assert_equal str, @df.group(:i).group_count.tdr_str
+      assert_equal str, @df.group(:i).count_all.tdr_str
+    end
+
+    test 'group group_count w/o nil' do
+      dataframe = DataFrame.new(x: %w[A A B B B C])
+      group = Group.new(dataframe, :x)
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
+        Vectors : 1 numeric, 1 string
+        # key          type   level data_preview
+        0 :x           string     3 ["A", "B", "C"]
+        1 :group_count int64      3 [2, 3, 1]
+      STR
+      assert_equal str, group.group_count.tdr_str
+      assert_equal str, group.count_all.tdr_str
+    end
+
     test 'group count with multiple keys and aggregation' do
       str = <<~STR
         RedAmber::DataFrame : 6 x 3 Vectors
@@ -259,28 +285,6 @@ class GroupTest < Test::Unit::TestCase
       ]
       assert_equal expect, @df.group(:i, :s).filters.map(&:to_a)
       assert_true @df.group(:i, :s).filters.all?(Vector)
-    end
-
-    test 'group_count' do
-      assert_equal <<~STR, @df.group(:i).group_count.tdr_str
-        RedAmber::DataFrame : 4 x 2 Vectors
-        Vectors : 2 numeric
-        # key          type  level data_preview
-        0 :i           uint8     4 [0, 1, 2, nil], 1 nil
-        1 :group_count int64     2 {2=>2, 1=>2}
-      STR
-    end
-
-    test 'group_count w/o nil' do
-      dataframe = DataFrame.new(x: %w[A A B B B C])
-      group = Group.new(dataframe, :x)
-      assert_equal <<~STR, group.group_count.tdr_str
-        RedAmber::DataFrame : 3 x 2 Vectors
-        Vectors : 1 numeric, 1 string
-        # key          type   level data_preview
-        0 :x           string     3 ["A", "B", "C"]
-        1 :group_count int64      3 [2, 3, 1]
-      STR
     end
 
     test 'each' do

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -100,6 +100,18 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, @df.group(:b).min(%i[i f s b]).tdr_str(tally: 0)
     end
 
+    test 'group one' do
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 3 Vectors
+        Vectors : 2 numeric, 1 string
+        # key       type   level data_preview
+        0 :s        string     3 ["A", "B", nil], 1 nil
+        1 :"one(i)" uint8      2 [0, 0, 1]
+        2 :"one(f)" double     3 [0.0, 1.1, 2.2]
+      STR
+      assert_equal str, @df.group(:s).one.tdr_str(tally: 0)
+    end
+
     test 'group product' do
       str = <<~STR
         RedAmber::DataFrame : 3 x 4 Vectors

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -21,6 +21,28 @@ class GroupTest < Test::Unit::TestCase
       )
     end
 
+    test 'group all' do
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
+        Vectors : 1 string, 1 boolean
+        # key       type    level data_preview
+        0 :s        string      3 ["A", "B", nil], 1 nil
+        1 :"all(b)" boolean     2 [false, false, true]
+      STR
+      assert_equal str, @df.group(:s).all.tdr_str(tally: 0)
+    end
+
+    test 'group any' do
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 2 Vectors
+        Vectors : 1 string, 1 boolean
+        # key       type    level data_preview
+        0 :s        string      3 ["A", "B", nil], 1 nil
+        1 :"any(b)" boolean     1 [true, true, true]
+      STR
+      assert_equal str, @df.group(:s).any.tdr_str(tally: 0)
+    end
+
     test 'group count' do
       str = <<~STR
         RedAmber::DataFrame : 4 x 5 Vectors
@@ -35,7 +57,7 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, @df.group(:i).count(%i[i f s b]).tdr_str(tally: 0)
     end
 
-    test 'group count (aggregation)' do
+    test 'group count unification' do
       str = <<~STR
         RedAmber::DataFrame : 4 x 2 Vectors
         Vectors : 2 numeric
@@ -47,7 +69,7 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, df.group(:i).count.tdr_str(tally: 0)
     end
 
-    test 'group with multiple keys and aggregation' do
+    test 'group count with multiple keys and aggregation' do
       str = <<~STR
         RedAmber::DataFrame : 6 x 3 Vectors
         Vectors : 2 numeric, 1 string

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -108,6 +108,18 @@ class GroupTest < Test::Unit::TestCase
       assert_equal str, @df.group(:b).mean(%i[i f b]).tdr_str(tally: 0)
     end
 
+    test 'group median' do
+      str = <<~STR
+        RedAmber::DataFrame : 3 x 3 Vectors
+        Vectors : 2 numeric, 1 string
+        # key          type   level data_preview
+        0 :s           string     3 ["A", "B", nil], 1 nil
+        1 :"median(i)" double     2 [0.0, 0.0, 1.0]
+        2 :"median(f)" double     3 [0.0, 1.1, 2.2]
+      STR
+      assert_equal str, @df.group(:s).median.tdr_str(tally: 0)
+    end
+
     test 'group min' do
       str = <<~STR
         RedAmber::DataFrame : 3 x 5 Vectors

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -22,7 +22,7 @@ class GroupTest < Test::Unit::TestCase
     end
 
     test 'group count' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 4 x 5 Vectors
         Vectors : 5 numeric
         # key         type  level data_preview
@@ -31,36 +31,36 @@ class GroupTest < Test::Unit::TestCase
         2 :"count(f)" int64     3 [2, 1, 2, 0]
         3 :"count(s)" int64     3 [2, 0, 2, 1]
         4 :"count(b)" int64     3 [2, 1, 2, 0]
-      OUTPUT
+      STR
       assert_equal str, @df.group(:i).count(%i[i f s b]).tdr_str(tally: 0)
     end
 
     test 'group count (aggregation)' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 4 x 2 Vectors
         Vectors : 2 numeric
         # key    type  level data_preview
         0 :i     uint8     4 [0, 1, 2, nil], 1 nil
         1 :count int64     3 [2, 1, 2, 0]
-      OUTPUT
+      STR
       df = @df.pick(:i, :f, :b)
       assert_equal str, df.group(:i).count.tdr_str(tally: 0)
     end
 
     test 'group with multiple keys and aggregation' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 6 x 3 Vectors
         Vectors : 2 numeric, 1 string
         # key    type   level data_preview
         0 :i     uint8      4 [0, 0, 1, 2, 2, ... ], 1 nil
         1 :s     string     3 ["A", "B", nil, "A", "B", ... ], 1 nil
         2 :count int64      2 [1, 1, 1, 1, 1, ... ]
-      OUTPUT
+      STR
       assert_equal str, @df.group(:i, :s).count.tdr_str(tally: 0)
     end
 
     test 'group max' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 5 Vectors
         Vectors : 2 numeric, 1 string, 2 boolean
         # key       type    level data_preview
@@ -69,12 +69,12 @@ class GroupTest < Test::Unit::TestCase
         2 :"max(f)" double      3 [2.2, 3.3, nil], 1 nil
         3 :"max(s)" string      2 ["B", "B", "A"]
         4 :"max(b)" boolean     3 [true, false, nil], 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).max(%i[i f s b]).tdr_str(tally: 0)
     end
 
     test 'group mean' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key        type    level data_preview
@@ -82,12 +82,12 @@ class GroupTest < Test::Unit::TestCase
         1 :"mean(i)" double      2 [1.0, 1.0, nil], 1 nil
         2 :"mean(f)" double      3 [NaN, 2.2, nil], 1 NaN, 1 nil
         3 :"mean(b)" double      3 [1.0, 0.0, nil], 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).mean(%i[i f b]).tdr_str(tally: 0)
     end
 
     test 'group min' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 5 Vectors
         Vectors : 2 numeric, 1 string, 2 boolean
         # key       type    level data_preview
@@ -96,12 +96,12 @@ class GroupTest < Test::Unit::TestCase
         2 :"min(f)" double      3 [0.0, 1.1, nil], 1 nil
         3 :"min(s)" string      1 ["A", "A", "A"]
         4 :"min(b)" boolean     3 [true, false, nil], 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).min(%i[i f s b]).tdr_str(tally: 0)
     end
 
     test 'group product' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key           type    level data_preview
@@ -109,24 +109,24 @@ class GroupTest < Test::Unit::TestCase
         1 :"product(i)" uint64      2 [0, 0, nil], 1 nil
         2 :"product(f)" double      3 [NaN, 3.63, nil], 1 NaN, 1 nil
         3 :"product(b)" uint64      3 [1, 0, nil], 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).product(%i[i f b]).tdr_str(tally: 0)
     end
 
     test 'group stddev' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 3 Vectors
         Vectors : 2 numeric, 1 boolean
         # key          type    level data_preview
         0 :b           boolean     3 [true, false, nil], 1 nil
         1 :"stddev(i)" double      3 [0.816496580927726, 1.0, nil], 1 nil
         2 :"stddev(f)" double      3 [NaN, 1.0999999999999999, nil], 1 NaN, 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).stddev(%i[i f]).tdr_str(tally: 0)
     end
 
     test 'group sum' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 4 Vectors
         Vectors : 3 numeric, 1 boolean
         # key       type    level data_preview
@@ -134,42 +134,42 @@ class GroupTest < Test::Unit::TestCase
         1 :"sum(i)" uint64      3 [3, 2, nil], 1 nil
         2 :"sum(f)" double      3 [NaN, 4.4, nil], 1 NaN, 1 nil
         3 :"sum(b)" uint64      3 [3, 0, nil], 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).sum(%i[i f b]).tdr_str(tally: 0)
     end
 
     test 'group variance' do
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 3 x 3 Vectors
         Vectors : 2 numeric, 1 boolean
         # key            type    level data_preview
         0 :b             boolean     3 [true, false, nil], 1 nil
         1 :"variance(i)" double      3 [0.6666666666666666, 1.0, nil], 1 nil
         2 :"variance(f)" double      3 [NaN, 1.2099999999999997, nil], 1 NaN, 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:b).variance(%i[i f]).tdr_str(tally: 0)
     end
 
     test 'group with a block' do
       assert_raise(GroupArgumentError) { @df.group(:i) {} }
 
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 4 x 2 Vectors
         Vectors : 2 numeric
         # key    type  level data_preview
         0 :i     uint8     4 [0, 1, 2, nil], 1 nil
         1 :count int64     3 [2, 1, 2, 0]
-      OUTPUT
+      STR
       assert_equal str, @df.group(:i) { count(:i, :f, :b) }.tdr_str(tally: 0)
 
-      str = <<~OUTPUT
+      str = <<~STR
         RedAmber::DataFrame : 4 x 3 Vectors
         Vectors : 3 numeric
         # key       type   level data_preview
         0 :i        uint8      4 [0, 1, 2, nil], 1 nil
         1 :count    uint8      3 [2, 1, 2, 0]
         2 :"sum(f)" double     4 [1.1, 2.2, NaN, nil], 1 NaN, 1 nil
-      OUTPUT
+      STR
       assert_equal str, @df.group(:i) { [count(:i, :f, :b), sum] }.tdr_str(tally: 0)
     end
 


### PR DESCRIPTION
Closes #272 .

Add new methods to `Group`.

- `Group#one`
- `Group#any`
- `Group#all`
- `Group#count_all` as an alias of `Group#group_count`
- `Group#count_uniq`
