### PR TITLE
Support Arrow 13.0.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN set -e; \
     libzmq3-dev
 
 # Install Apache Arrow
-ARG APACHE_ARROW_VERSION=12.0.1-1
+ARG APACHE_ARROW_VERSION=13.0.0-1
 ARG arrow_deb_tmp=/tmp/apache-arrow-apt-source-latest.deb
 ARG arrow_apt_source=https://apache.jfrog.io/artifactory/arrow/ubuntu/pool/jammy/main/a/apache-arrow-apt-source/apache-arrow-apt-source_${APACHE_ARROW_VERSION}_all.deb
 RUN set -e; \

--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# Explicitly set ownership of /workspaces to vscode:vscode
+# Because recent runner has uid=1001(runner), gid=999(docker)
+sudo chown -R $(id -un):$(id -un) /workspaces
+
 # Install language and set timezone
 # You should change here if you use another
 sudo apt-get update

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -4,12 +4,11 @@ on:
     branches:
       - main
   pull_request:
-  
+
 jobs:
   test:
     name: fedora
     runs-on: ubuntu-latest
-    
     steps:
       - name: Setup Podman
         run: |
@@ -25,11 +24,11 @@ jobs:
           {
               echo 'FROM fedora:39'
               echo 'RUN dnf -y update'
-              echo 'RUN dnf -y install gcc-c++ git libarrow-devel libarrow-glib-devel ruby-devel'
+              echo 'RUN dnf -y install gcc-c++ git libarrow-devel libarrow-glib-devel ruby-devel libyaml-devel'
               echo 'RUN dnf clean all'
               echo 'COPY red_amber red_amber'
               echo 'WORKDIR /red_amber'
               echo 'RUN bundle install'
           } > podmanfile
           echo 'RUN bundle exec rake test' >> podmanfile
-          podman build --tag fedora38test -f ./podmanfile
+          podman build --tag fedora_test -f ./podmanfile

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 group :test do
   gem 'rake'
 
-  gem 'red-parquet', '~> 12.0.0'
+  gem 'red-parquet', '>= 12.0.0'
   gem 'rover-df', '~> 0.3.0'
 
   gem 'rubocop'

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,7 @@ RedAmberをインストールする前に、下記のライブラリのインス
 
       ```
       sudo dnf update
-      sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel
+      sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel libyaml-devel
       ```
 
   - macOS の場合は、Homebrewを使用する:

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,10 +29,10 @@ Rubyistのためのデータフレームライブラリ.
 
 ### ライブラリ
 ```ruby
-gem 'red-arrow',   '~> 12.0.0' # お使いの環境に合わせた Apache Arrow が必要です
-　　　　　　　　　　　　　　　　　# 下記のインストールを参照してください
+gem 'red-arrow',   '>= 12.0.0' # お使いの環境に合わせた Apache Arrow が必要です
+                               # 下記のインストールを参照してください
 gem 'red-arrow-numo-narray'    # 必要に応じて。Numo::NArray との連携またはランダムサンプリングが必要な場合。
-gem 'red-parquet', '~> 12.0.0' # 必要に応じて。Parquet の入出力が必要な場合。
+gem 'red-parquet', '>= 12.0.0' # 必要に応じて。Parquet の入出力が必要な場合。
 gem 'red-datasets-arrow'       # 必要に応じて。Red Datasets を利用する場合。
 gem 'red-arrow-activerecord'   # 必要に応じて。Active Record とのデータ交換が必要な場合。
 gem 'rover-df',                # 必要に応じて。Rover::DataFrame に対する入出力が必要な場合。
@@ -42,9 +42,9 @@ gem 'rover-df',                # 必要に応じて。Rover::DataFrame に対す
 
 RedAmberをインストールする前に、下記のライブラリのインストールが必要です。
 
-- Apache Arrow (~> 12.0.0)
-- Apache Arrow GLib (~> 12.0.0)
-- Apache Parquet GLib (~> 12.0.0)  # Parquetの入出力が必要な場合。
+- Apache Arrow (>= 12.0.0)
+- Apache Arrow GLib (>= 12.0.0)
+- Apache Parquet GLib (>= 12.0.0)  # Parquetの入出力が必要な場合。
 
 環境ごとの詳しいインストール方法は、 [Apache Arrow install document](https://arrow.apache.org/install/) を参照してください。
 
@@ -75,10 +75,10 @@ RedAmberをインストールする前に、下記のライブラリのインス
 Apache Arrowがインストールできたら、下記の行をGemfileに追加してください:
 
 ```ruby
-gem 'red-arrow',   '~> 12.0.0'
+gem 'red-arrow',   '>= 12.0.0'
 gem 'red_amber'
 gem 'red-arrow-numo-narray'    # 必要に応じて。Numo::NArray との連携またはランダムサンプリングが必要な場合。
-gem 'red-parquet', '~> 12.0.0' # 必要に応じて。Parquetの入出力が必要な場合。
+gem 'red-parquet', '>= 12.0.0' # 必要に応じて。Parquetの入出力が必要な場合。
 gem 'red-datasets-arrow'       # 必要に応じて。Red Datasets を利用する場合。
 gem 'red-arrow-activerecord'   # 必要に応じて。Active Record とのデータ交換が必要な場合。
 gem 'rover-df',                # 必要に応じて。Rover::DataFrameに対する入出力が必要な場合。

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [Apache Arrow install document](https://arrow.apache.org/install/).
 
       ```
       sudo dnf update
-      sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel
+      sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel libyaml-devel
       ```
 
   - On macOS, using Homebrew:

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Supported Ruby version is >= 3.0.
 
 ### Required libraries
 ```ruby
-gem 'red-arrow',   '~> 12.0.0' # Requires Apache Arrow (see installation below).
+gem 'red-arrow',   '>= 12.0.0' # Requires Apache Arrow (see installation below).
 gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray,
                                # or use random sampling feature.
-gem 'red-parquet', '~> 12.0.0' # Optional, if you use IO from/to parquet.
+gem 'red-parquet', '>= 12.0.0' # Optional, if you use IO from/to parquet.
 gem 'red-datasets-arrow'       # Optional, if you use Red Datasets.
 gem 'red-arrow-activerecord'   # Optional, if you use Active Record.
 gem 'rover-df',                # Optional, if you use IO from/to Rover::DataFrame.
@@ -42,9 +42,9 @@ gem 'rover-df',                # Optional, if you use IO from/to Rover::DataFram
 
 Install requirements before you install RedAmber.
 
-- Apache Arrow (~> 12.0.0)
-- Apache Arrow GLib (~> 12.0.0)
-- Apache Parquet GLib (~> 12.0.0)  # If you use IO from/to parquet
+- Apache Arrow (>= 12.0.0)
+- Apache Arrow GLib (>= 12.0.0)
+- Apache Parquet GLib (>= 12.0.0)  # If you use IO from/to parquet
 
 See [Apache Arrow install document](https://arrow.apache.org/install/).
 
@@ -75,11 +75,11 @@ See [Apache Arrow install document](https://arrow.apache.org/install/).
 If you prepared Apache Arrow, add these lines to your Gemfile:
 
 ```ruby
-gem 'red-arrow',   '~> 12.0.0'
+gem 'red-arrow',   '>= 12.0.0'
 gem 'red_amber'
 gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray
                                # or use random sampling feature.
-gem 'red-parquet', '~> 12.0.0' # Optional, if you use IO from/to parquet
+gem 'red-parquet', '>= 12.0.0' # Optional, if you use IO from/to parquet
 gem 'red-datasets-arrow'       # Optional, recommended if you use Red Datasets
 gem 'red-arrow-activerecord'   # Optional, if you use Active Record
 gem 'rover-df',                # Optional, if you use IO from/to Rover::DataFrame.

--- a/doc/qmd/examples_of_red_amber.qmd
+++ b/doc/qmd/examples_of_red_amber.qmd
@@ -13,7 +13,7 @@ format:
     colorlinks: true
 ---
 
-For RedAmber Version 0.5.1-HEAD and Arrow version 12.0.1 .
+For RedAmber Version 0.5.1, 0.5.2 and Arrow version 12.0.1, 13.0.0 .
 
 ## 1. Install
 
@@ -21,9 +21,9 @@ Install requirements before you install RedAmber.
 
 - Ruby (>= 3.0)
 
-- Apache Arrow (~> 12.0.0)
-- Apache Arrow GLib (~> 12.0.0)
-- Apache Parquet GLib (~> 12.0.0)  # if you need IO from/to Parquet resource.
+- Apache Arrow (>= 12.0.0)
+- Apache Arrow GLib (>= 12.0.0)
+- Apache Parquet GLib (>= 12.0.0)  # if you need IO from/to Parquet resource.
 
   See [Apache Arrow install document](https://arrow.apache.org/install/).
 
@@ -56,11 +56,11 @@ Install requirements before you install RedAmber.
 If you prepared Apache Arrow, add these lines to your Gemfile:
 
 ```ruby
-gem 'red-arrow',   '~> 12.0.0'
+gem 'red-arrow',   '>= 12.0.0'
 gem 'red_amber'
 gem 'red-arrow-numo-narray'    # Optional, recommended if you use inputs from Numo::NArray
                                # or use random sampling feature.
-gem 'red-parquet', '~> 12.0.0' # Optional, if you use IO from/to parquet
+gem 'red-parquet', '>= 12.0.0' # Optional, if you use IO from/to parquet
 gem 'red-datasets-arrow'       # Optional, recommended if you use Red Datasets
 gem 'red-arrow-activerecord'   # Optional, if you use Active Record
 gem 'rover-df',                # Optional, if you use IO from/to Rover::DataFrame.

--- a/doc/qmd/examples_of_red_amber.qmd
+++ b/doc/qmd/examples_of_red_amber.qmd
@@ -40,7 +40,7 @@ Install requirements before you install RedAmber.
   - On Fedora 38 (Rawhide):
     ```shell
     sudo dnf update
-    sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel
+    sudo dnf -y install gcc-c++ libarrow-devel libarrow-glib-devel ruby-devel libyaml-devel
 
 
   - On macOS, you can install Apache Arrow C++ library using Homebrew:

--- a/red_amber.gemspec
+++ b/red_amber.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'red-arrow', '~> 12.0.0'
+  spec.add_dependency 'red-arrow', '>= 12.0.0'
 
   # Development dependency has gone to the Gemfile (rubygems/bundler#7237)
 


### PR DESCRIPTION
Closes #273 .

This will support Arrow 13.0.0 .

Arrow 13.0.0 is compatible with RedAmber 0.5.1 .
I will update gemspec and Gemfile to enable 13.0.0 by changing `~> 12.0.0` to `>= 12.0.0`.

Dev Container will use Arrow 13.0.0 .