### PR TITLE
Make DataFrame#to_wide fill nil reshaping

### DIFF
--- a/test/test_data_frame_reshaping.rb
+++ b/test/test_data_frame_reshaping.rb
@@ -128,5 +128,20 @@ class DataFrameReshapingTest < Test::Unit::TestCase
       df = @df.rename(NAME: :key1, VALUE: :key2)
       assert_equal @str, df.to_wide(name: :key1, value: :key2).to_s
     end
+
+    test '#to_wide with missing values' do
+      df = DataFrame.new(
+        names: %w[name1 name1 name1 name2 name2 name3 name3 name3],
+        NAME: %w[One Two Three One Three One Two Three],
+        VALUE: [1.1, 2.1, 3.1, 1.2, 3.2, 1.3, 2.3, 3.3]
+      )
+      wide = DataFrame.new(
+        names: %w[name1 name2 name3],
+        One: [1.1, 1.2, 1.3],
+        Two: [2.1, nil, 2.3],
+        Three: [3.1, 3.2, 3.3]
+      )
+      assert_equal wide, df.to_wide(fill_missing: true)
+    end
   end
 end


### PR DESCRIPTION
This is an example to fix #287, though I'm not sure whether it's best to add option to `DataFrame#to_wide` or to add another method. Additionally, this implementation may require performance improvement.

This pull request is create just for discussion. Feel free to close without merging.