### PR TITLE
Use arrow 15.0.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN set -e; \
     libzmq3-dev
 
 # Install Apache Arrow
-ARG APACHE_ARROW_VERSION=13.0.0-1
+ARG APACHE_ARROW_VERSION=15.0.0-1
 ARG arrow_deb_tmp=/tmp/apache-arrow-apt-source-latest.deb
 ARG arrow_apt_source=https://apache.jfrog.io/artifactory/arrow/ubuntu/pool/jammy/main/a/apache-arrow-apt-source/apache-arrow-apt-source_${APACHE_ARROW_VERSION}_all.deb
 RUN set -e; \

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt-get -y install podman
-          podman pull fedora:39
+          podman pull fedora:rawhide
       - name: Get source
         uses: actions/checkout@v3
         with:
@@ -22,7 +22,7 @@ jobs:
       - name: Create container and run tests
         run: |
           {
-              echo 'FROM fedora:39'
+              echo 'FROM fedora:rawhide'
               echo 'RUN dnf -y update'
               echo 'RUN dnf -y install gcc-c++ git libarrow-devel libarrow-glib-devel ruby-devel libyaml-devel'
               echo 'RUN dnf clean all'

--- a/bin/Gemfile
+++ b/bin/Gemfile
@@ -6,9 +6,9 @@ gem 'irb'
 gem 'iruby'
 
 gem 'numo-narray'
-gem 'red-arrow', '~> 12.0.0'
+gem 'red-arrow', '~> 15.0.0'
 gem 'red-arrow-numo-narray'
-gem 'red-parquet', '~> 12.0.0'
+gem 'red-parquet', '~> 15.0.0'
 
 gem 'red_amber', path: '..'
 gem 'red-amber-view'


### PR DESCRIPTION
This PR will ensure;

- Minimum requirement for Arrow is 12.0.0 (unchanged), will use 15.0.0 if it is installed.
- Use Arrow 15.0.0 in Fedora Rawhide in CI.
- Use Arrow 15.0.0 in Docker image.

Closes #284 .