### PR TITLE
Add ruby3.3 in ci

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -56,7 +56,7 @@ ARG USER_GID=$USER_UID
 USER $USERNAME
 
 # Install rbenv
-ARG RBENV_RUBY=3.2.2
+ARG RBENV_RUBY=3.3.0
 RUN set -e; \
     git clone https://github.com/rbenv/rbenv.git $HOME/.rbenv; \
     echo 'eval "$($HOME/.rbenv/bin/rbenv init -)"' >> $HOME/.profile; \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos] # windows, if: runner.os == 'Windows'
-        ruby: ['3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}-latest
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# x86-64/Ubuntu-22.04/python-3.10.11/lab-3.6.3/notebook-6.5.4/2023-05-15
-ARG BASE_IMAGE_TAG=513d0cb8a67c
+# x86-64/Ubuntu-22.04/python-3.11.7/lab-4.0.11/notebook-7.0.7/2024-01-29
+ARG BASE_IMAGE_TAG=3692e3a84cd6
 
 FROM jupyter/minimal-notebook:$BASE_IMAGE_TAG
 


### PR DESCRIPTION
This PR will;

- Add Ruby 3.3 in CI.
- Upgrade Jupyter Lab environment including Ruby 3.3.0 .
- Use Ruby 3.3.0 in Dev Container.

Closes #293 .
