### PR TITLE
Fix/type preservation empty dataframes

### DIFF
--- a/lib/red_amber/data_frame_variable_operation.rb
+++ b/lib/red_amber/data_frame_variable_operation.rb
@@ -675,9 +675,18 @@ module RedAmber
           raise DataFrameArgumentError, "Data size mismatch (#{data.size} != #{size})"
         end
 
-        a = Arrow::Array.new(data.is_a?(Vector) ? data.to_a : data)
-        fields[i] = Arrow::Field.new(key, a.value_data_type)
-        arrays[i] = Arrow::ChunkedArray.new([a])
+        if data.respond_to?(:to_arrow_chunked_array)
+          chunked_array = data.to_arrow_chunked_array
+        else
+          if data.respond_to?(:to_arrow_array)
+            a = data.to_arrow_array
+          else
+            a = Arrow::Array.new(data)
+          end
+          chunked_array = Arrow::ChunkedArray.new([a])
+        end
+        fields[i] = Arrow::Field.new(key, chunked_array.value_data_type)
+        arrays[i] = chunked_array
       end
       [fields, arrays]
     end

--- a/lib/red_amber/vector.rb
+++ b/lib/red_amber/vector.rb
@@ -198,6 +198,22 @@ module RedAmber
     alias_method :values, :to_ary
     alias_method :entries, :to_ary
 
+    # Convert to an Arrow::Array.
+    #
+    # @return [Arrow::Array]
+    #   Apache Arrow array representation.
+    def to_arrow_array
+      @data.to_arrow_array
+    end
+
+    # Convert to an Arrow::ChunkedArray.
+    #
+    # @return [Arrow::ChunkedArray]
+    #   Apache Arrow chunked array representation.
+    def to_arrow_chunked_array
+      @data.to_arrow_chunked_array
+    end
+
     # Indeces from 0 to size-1 by Array.
     #
     # @return [Array]

--- a/test/test_data_frame_variable_operation.rb
+++ b/test/test_data_frame_variable_operation.rb
@@ -439,6 +439,21 @@ class DataFrameVariableOperationTest < Test::Unit::TestCase
       assert_equal str2, @df2.assign { assigner2.to_a }.tdr_str
     end
 
+    sub_test_case 'Dataframe with zero n_records' do
+      test 'assign by block' do
+        str = <<~STR
+          RedAmber::DataFrame : 0 x 4 Vectors
+          Vectors : 2 numeric, 1 string, 1 boolean
+          # key type    level data_preview
+          0 :a  uint8       0 []
+          1 :b  double      0 []
+          2 :c  string      0 []
+          3 :d  boolean     0 []
+        STR
+        assert_equal str, @df.filter(@df.c == "nonexistent").assign(:b) { b.multiply(1) }.tdr_str
+      end
+    end
+
     test 'assign by both args and block' do
       assert_raise(DataFrameArgumentError) { @df2.assign(:key) {} } # rubocop:disable Lint/EmptyBlock
 

--- a/test/test_group.rb
+++ b/test/test_group.rb
@@ -250,7 +250,7 @@ class GroupTest < Test::Unit::TestCase
         Vectors : 3 numeric
         # key       type   level data_preview
         0 :i        uint8      4 [0, 1, 2, nil], 1 nil
-        1 :count    uint8      3 [2, 1, 2, 0]
+        1 :count    int64      3 [2, 1, 2, 0]
         2 :"sum(f)" double     4 [1.1, 2.2, NaN, nil], 1 NaN, 1 nil
       STR
       assert_equal str, @df.group(:i) { [count(:i, :f, :b), sum] }.tdr_str(tally: 0)


### PR DESCRIPTION
It looks like manipulating a column in an empty data frame defaults the result to a type of `:string`.